### PR TITLE
Add port-mode switch script to support 100G 50G 10G_50G qsfp modes.

### DIFF
--- a/debian/platform-modules-dx010.install
+++ b/debian/platform-modules-dx010.install
@@ -1,2 +1,3 @@
 dx010/scripts/dx010_check_qsfp.sh usr/local/bin
+dx010/scripts/port-mode.sh usr/local/bin
 dx010/cfg/dx010-modules.conf etc/modules-load.d

--- a/dx010/scripts/port-mode.sh
+++ b/dx010/scripts/port-mode.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+mode=$1
+
+if [ "$mode" = "100G" ]; then
+    cp /usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010/minigraph.xml /etc/sonic/minigraph.xml
+    echo "32x100G mode is used"
+elif [ "$mode" = "10G-50G" ]; then
+    cp /usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-10-50/minigraph.xml /etc/sonic/minigraph.xml
+    echo "96x10G+16x50G mode is used"
+elif [ "$mode" = "50G" ]; then
+    cp /usr/share/sonic/device/x86_64-cel_seastone-r0/Seastone-DX010-50/minigraph.xml /etc/sonic/minigraph.xml
+    echo "64x100G mode is used"
+else
+    echo "Please enter 100G, 10G-50G or 50G mode"
+    exit
+fi
+
+docker stop syncd
+docker stop swss
+docker rm syncd
+docker rm swss
+echo " rebooting the box"
+reboot


### PR DESCRIPTION
Add port-mode switch script to device package.
NOTE: This require the add-port-mode-switch branch in sonic-buildimage.