### PR TITLE
Add silverstone sensors read

### DIFF
--- a/debian/platform-modules-silverstone.init
+++ b/debian/platform-modules-silverstone.init
@@ -22,6 +22,7 @@ start)
         modprobe baseboard
         modprobe switchboard
         modprobe mc24lc64t
+        modprobe ipmi_devintf
 
         # Instantiate TLV EEPROM device on I801 bus 
         devname=`cat /sys/bus/i2c/devices/i2c-0/name`

--- a/debian/platform-modules-silverstone.install
+++ b/debian/platform-modules-silverstone.install
@@ -1,1 +1,2 @@
 silverstone/cfg/silverstone-modules.conf etc/modules-load.d
+questone2/scripts/sensors usr/bin

--- a/debian/platform-modules-silverstone.install
+++ b/debian/platform-modules-silverstone.install
@@ -1,2 +1,3 @@
 silverstone/cfg/silverstone-modules.conf etc/modules-load.d
 questone2/scripts/sensors usr/bin
+

--- a/silverstone/scripts/sensors
+++ b/silverstone/scripts/sensors
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -x "$(command -v ipmitool)" ] ; then
+    echo "SENSOR           | VALUE      | UNITS      | STATE | LO NOREC  | LO CRIT   | LO NOCRIT | UP NOCRIT | UP CRIT   | UP NOREC"
+	ipmitool sensor list full
+else
+    echo "ipmitool is not installed"
+
+fi

--- a/silverstone/scripts/sensors
+++ b/silverstone/scripts/sensors
@@ -7,3 +7,4 @@ else
     echo "ipmitool is not installed"
 
 fi
+


### PR DESCRIPTION
Add the ipmitool command to read sensors from BMC.  
The script will replace the originals lm-sensors.