### PR TITLE
[Phalanx/Fishbones] Fix bug loading i2c_imc in init scritp.

### DIFF
--- a/debian/platform-modules-fishbone32.init
+++ b/debian/platform-modules-fishbone32.init
@@ -17,7 +17,7 @@ start)
 
         # Add driver to support HW
         modprobe dimm-bus
-        modprobe i2c-imc
+        modprobe i2c-imc allow_unsafe_access=1
         modprobe i2c-dev
         modprobe baseboard_cpld
         modprobe switchboard_fpga

--- a/debian/platform-modules-fishbone48.init
+++ b/debian/platform-modules-fishbone48.init
@@ -18,7 +18,7 @@ start)
         # Add driver to support HW
         modprobe i2c-dev
         modprobe dimm-bus
-        modprobe i2c-imc
+        modprobe i2c-imc allow_unsafe_access=1
         modprobe baseboard_cpld
         modprobe switchboard_fpga
 

--- a/debian/platform-modules-phalanx.init
+++ b/debian/platform-modules-phalanx.init
@@ -18,7 +18,7 @@ start)
         # Add driver to support HW
         modprobe i2c-dev
         modprobe dimm-bus
-        modprobe i2c-imc
+        modprobe i2c-imc allow_unsafe_access=1
         modprobe baseboard_cpld
         modprobe switchboard_fpga
         


### PR DESCRIPTION
Fix platform init script loading failed.  
Add option **allow_unsafe_access=1** in i2c_imc module loading.