### PR TITLE
Remove i2c devices overlap bmc

### DIFF
--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.2.3"
+#define MOD_VERSION "0.3.0"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -59,7 +59,7 @@ static int  majorNumber;
 #define FPGA_PCI_NAME "fishbone32_fpga_pci"
 #define DEVICE_NAME "fwupgrade"
 
-
+static bool allow_unsafe_i2c_access;
 
 static int smbus_access(struct i2c_adapter *adapter, u16 addr,
                         unsigned short flags, char rw, u8 cmd,
@@ -1698,7 +1698,7 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
     struct resource *res;
     int ret = 0;
     int portid_count;
-    uint8_t fan_cpld_version, bb_cpld_version, cpld1_version, cpld2_version;
+    uint8_t cpld1_version, cpld2_version;
     uint16_t prev_i2c_switch = 0;
     struct sff_device_data *sff_data;
 
@@ -1822,6 +1822,11 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
     }
 
     for (portid_count = I2C_MASTER_CH_1; portid_count <= I2C_MASTER_CH_TOTAL; portid_count++){
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < I2C_MASTER_CH_7 ||  
+                portid_count == I2C_MASTER_CH_9 || portid_count == I2C_MASTER_CH_10 )
+                continue;
+        }
         ret = i2c_core_init(portid_count, I2C_DIV_100K, fpga_dev.data_base_addr);
         if (ret < 0) {
             dev_err(&pdev->dev, "Unable to init I2C core %d\n", portid_count);
@@ -1839,6 +1844,12 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
     }
 
     for (portid_count = 0 ; portid_count < VIRTUAL_I2C_PORT_LENGTH ; portid_count++) {
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < SW1_I2C_CPLD_INDEX ){
+                fpga_data->i2c_adapter[portid_count] = NULL;
+                continue;
+            }
+        }
         fpga_data->i2c_adapter[portid_count] = fishbone32_i2c_init(pdev, portid_count, VIRTUAL_I2C_BUS_OFFSET);
     }
 
@@ -1866,23 +1877,23 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
 #ifdef TEST_MODE
     return 0;
 #endif
-    fpga_i2c_access(fpga_data->i2c_adapter[FAN_I2C_CPLD_INDEX], FAN_CPLD_SLAVE_ADDR, 0x00,
-                    I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&fan_cpld_version);
-    fpga_i2c_access(fpga_data->i2c_adapter[BB_I2C_CPLD_INDEX], BB_CPLD_SLAVE_ADDR, 0x00,
-                    I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&bb_cpld_version);
     fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], CPLD1_SLAVE_ADDR, 0x00,
                     I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&cpld1_version);
     fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], CPLD2_SLAVE_ADDR, 0x00,
                     I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&cpld2_version);
 
-    printk(KERN_INFO "Fan CPLD Version: %2.2x\n", cpld1_version);
-    printk(KERN_INFO "BaseBoard CPLD Version: %2.2x\n", cpld2_version);
     printk(KERN_INFO "Switch CPLD1 Version: %2.2x\n", cpld1_version);
     printk(KERN_INFO "Switch CPLD2 Version: %2.2x\n", cpld2_version);
 
 
     /* Init I2C buses that has PCA9548 switch device. */
     for (portid_count = 0; portid_count < VIRTUAL_I2C_PORT_LENGTH; portid_count++) {
+
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < SW1_I2C_CPLD_INDEX ){
+                continue;
+            }
+        }
 
         struct i2c_dev_data *dev_data;
         unsigned char master_bus;
@@ -1924,6 +1935,11 @@ static int fishbone32_drv_remove(struct platform_device *pdev)
     }
 
     for (portid_count = I2C_MASTER_CH_1; portid_count <= I2C_MASTER_CH_TOTAL; portid_count++){
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < I2C_MASTER_CH_7 ||  
+                portid_count == I2C_MASTER_CH_9 || portid_count == I2C_MASTER_CH_10 )
+                continue;
+        }
         i2c_core_deinit(portid_count, fpga_dev.data_base_addr);
     }
 
@@ -2182,6 +2198,9 @@ void fishbone32_exit(void)
 
 module_init(fishbone32_init);
 module_exit(fishbone32_exit);
+
+module_param(allow_unsafe_i2c_access, bool, 0400);
+MODULE_PARM_DESC(allow_unsafe_i2c_access, "enable i2c busses despite potential races against BMC bus access");
 
 MODULE_AUTHOR("Pradchaya P. <pphuchar@celestica.com>");
 MODULE_DESCRIPTION("Celestica Fishbone32 switchboard platform driver");

--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -1845,7 +1845,7 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
 
     for (portid_count = 0 ; portid_count < VIRTUAL_I2C_PORT_LENGTH ; portid_count++) {
         if(!allow_unsafe_i2c_access){
-            if( portid_count < SW1_I2C_CPLD_INDEX ){
+            if( portid_count >= FAN_I2C_CPLD_INDEX && portid_count < SW_I2C_CPLD_INDEX ){
                 fpga_data->i2c_adapter[portid_count] = NULL;
                 continue;
             }
@@ -1890,7 +1890,7 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
     for (portid_count = 0; portid_count < VIRTUAL_I2C_PORT_LENGTH; portid_count++) {
 
         if(!allow_unsafe_i2c_access){
-            if( portid_count < SW1_I2C_CPLD_INDEX ){
+            if( portid_count >= FAN_I2C_CPLD_INDEX && portid_count < SW_I2C_CPLD_INDEX ){
                 continue;
             }
         }

--- a/fishbone48/modules/switchboard_fpga.c
+++ b/fishbone48/modules/switchboard_fpga.c
@@ -25,7 +25,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.2.3"
+#define MOD_VERSION "0.3.0"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -60,7 +60,7 @@ static int  majorNumber;
 #define FPGA_PCI_NAME "fishbone48_fpga_pci"
 #define DEVICE_NAME "fwupgrade"
 
-
+static bool allow_unsafe_i2c_access;
 
 static int smbus_access(struct i2c_adapter *adapter, u16 addr,
                         unsigned short flags, char rw, u8 cmd,
@@ -1714,7 +1714,7 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
     struct resource *res;
     int ret = 0;
     int portid_count;
-    uint8_t fan_cpld_version, bb_cpld_version, cpld1_version, cpld2_version;
+    uint8_t cpld1_version, cpld2_version;
     uint16_t prev_i2c_switch = 0;
     struct sff_device_data *sff_data;
 
@@ -1838,6 +1838,11 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
     }
 
     for (portid_count = I2C_MASTER_CH_1; portid_count <= I2C_MASTER_CH_TOTAL; portid_count++){
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < I2C_MASTER_CH_7 ||  
+                portid_count == I2C_MASTER_CH_9 || portid_count == I2C_MASTER_CH_10 )
+                continue;
+        }
         ret = i2c_core_init(portid_count, I2C_DIV_100K, fpga_dev.data_base_addr);
         if (ret < 0) {
             dev_err(&pdev->dev, "Unable to init I2C core %d\n", portid_count);
@@ -1855,6 +1860,12 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
     }
 
     for (portid_count = 0 ; portid_count < VIRTUAL_I2C_PORT_LENGTH ; portid_count++) {
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < SW1_I2C_CPLD_INDEX ){
+                fpga_data->i2c_adapter[portid_count] = NULL;
+                continue;
+            }
+        }
         fpga_data->i2c_adapter[portid_count] = fishbone48_i2c_init(pdev, portid_count, VIRTUAL_I2C_BUS_OFFSET);
     }
 
@@ -1882,23 +1893,23 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
 #ifdef TEST_MODE
     return 0;
 #endif
-    fpga_i2c_access(fpga_data->i2c_adapter[FAN_I2C_CPLD_INDEX], FAN_CPLD_SLAVE_ADDR, 0x00,
-                    I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&fan_cpld_version);
-    fpga_i2c_access(fpga_data->i2c_adapter[BB_I2C_CPLD_INDEX], BB_CPLD_SLAVE_ADDR, 0x00,
-                    I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&bb_cpld_version);
     fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], CPLD1_SLAVE_ADDR, 0x00,
                     I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&cpld1_version);
     fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], CPLD2_SLAVE_ADDR, 0x00,
                     I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&cpld2_version);
 
-    printk(KERN_INFO "Fan CPLD Version: %2.2x\n", cpld1_version);
-    printk(KERN_INFO "BaseBoard CPLD Version: %2.2x\n", cpld2_version);
     printk(KERN_INFO "Switch CPLD1 Version: %2.2x\n", cpld1_version);
     printk(KERN_INFO "Switch CPLD2 Version: %2.2x\n", cpld2_version);
 
 
     /* Init I2C buses that has PCA9548 switch device. */
     for (portid_count = 0; portid_count < VIRTUAL_I2C_PORT_LENGTH; portid_count++) {
+
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < SW1_I2C_CPLD_INDEX ){
+                continue;
+            }
+        }
 
         struct i2c_dev_data *dev_data;
         unsigned char master_bus;
@@ -1940,6 +1951,11 @@ static int fishbone48_drv_remove(struct platform_device *pdev)
     }
 
     for (portid_count = I2C_MASTER_CH_1; portid_count <= I2C_MASTER_CH_TOTAL; portid_count++){
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < I2C_MASTER_CH_7 ||  
+                portid_count == I2C_MASTER_CH_9 || portid_count == I2C_MASTER_CH_10 )
+                continue;
+        }
         i2c_core_deinit(portid_count, fpga_dev.data_base_addr);
     }
 
@@ -2198,6 +2214,9 @@ void fishbone48_exit(void)
 
 module_init(fishbone48_init);
 module_exit(fishbone48_exit);
+
+module_param(allow_unsafe_i2c_access, bool, 0400);
+MODULE_PARM_DESC(allow_unsafe_i2c_access, "enable i2c busses despite potential races against BMC bus access");
 
 MODULE_AUTHOR("Pradchaya P. <pphuchar@celestica.com>");
 MODULE_DESCRIPTION("Celestica Fishbone48 switchboard platform driver");

--- a/fishbone48/modules/switchboard_fpga.c
+++ b/fishbone48/modules/switchboard_fpga.c
@@ -1861,7 +1861,7 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
 
     for (portid_count = 0 ; portid_count < VIRTUAL_I2C_PORT_LENGTH ; portid_count++) {
         if(!allow_unsafe_i2c_access){
-            if( portid_count < SW1_I2C_CPLD_INDEX ){
+            if( portid_count >= FAN_I2C_CPLD_INDEX && portid_count < SW_I2C_CPLD_INDEX ){
                 fpga_data->i2c_adapter[portid_count] = NULL;
                 continue;
             }
@@ -1906,7 +1906,7 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
     for (portid_count = 0; portid_count < VIRTUAL_I2C_PORT_LENGTH; portid_count++) {
 
         if(!allow_unsafe_i2c_access){
-            if( portid_count < SW1_I2C_CPLD_INDEX ){
+            if( portid_count >= FAN_I2C_CPLD_INDEX && portid_count < SW_I2C_CPLD_INDEX ){
                 continue;
             }
         }

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.1.0"
+#define MOD_VERSION "0.2.0"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -59,7 +59,7 @@ static int  majorNumber;
 #define FPGA_PCI_NAME "phalanx_fpga_pci"
 #define DEVICE_NAME "fwupgrade"
 
-
+static bool allow_unsafe_i2c_access;
 
 static int smbus_access(struct i2c_adapter *adapter, u16 addr,
                         unsigned short flags, char rw, u8 cmd,
@@ -1155,6 +1155,14 @@ static struct attribute_group fancpld_attr_grp = {
     .attrs = fancpld_attrs,
 };
 
+static struct attribute *fancpld_no_attrs[] = {
+    NULL,
+};
+
+static struct attribute_group fancpld_no_attr_grp = {
+    .attrs = fancpld_no_attrs,
+};
+
 /* QSFP/SFP+ attributes */
 static ssize_t qsfp_modirq_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
@@ -2113,7 +2121,6 @@ static int phalanx_drv_probe(struct platform_device *pdev)
     struct resource *res;
     int ret = 0;
     int portid_count;
-    uint8_t fan_cpld_version, bb_cpld_version;
     uint8_t cpld1_version, cpld2_version, cpld3_version, cpld4_version;
     uint16_t prev_i2c_switch = 0;
     struct sff_device_data *sff_data;
@@ -2265,7 +2272,10 @@ static int phalanx_drv_probe(struct platform_device *pdev)
         kzfree(fpga_data);
         return -ENOMEM;
     }
-    ret = sysfs_create_group(fancpld, &fancpld_attr_grp);
+    if(!allow_unsafe_i2c_access)
+        ret = sysfs_create_group(fancpld, &fancpld_no_attr_grp);
+    else
+        ret = sysfs_create_group(fancpld, &fancpld_attr_grp);
     if (ret != 0) {
         printk(KERN_ERR "Cannot create FAN_CPLD sysfs attributes\n");
         kobject_put(fancpld);
@@ -2343,6 +2353,12 @@ static int phalanx_drv_probe(struct platform_device *pdev)
     }
 
     for (portid_count = I2C_MASTER_CH_1; portid_count <= I2C_MASTER_CH_TOTAL; portid_count++){
+
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < I2C_MASTER_CH_7 ||  
+                portid_count == I2C_MASTER_CH_9 || portid_count == I2C_MASTER_CH_10 )
+                continue;
+        }
         ret = i2c_core_init(portid_count, I2C_DIV_100K, fpga_dev.data_base_addr);
         if (ret < 0) {
             dev_err(&pdev->dev, "Unable to init I2C core %d\n", portid_count);
@@ -2366,6 +2382,12 @@ static int phalanx_drv_probe(struct platform_device *pdev)
     }
 
     for (portid_count = 0 ; portid_count < VIRTUAL_I2C_PORT_LENGTH ; portid_count++) {
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < SW1_I2C_CPLD_INDEX ){
+                fpga_data->i2c_adapter[portid_count] = NULL;
+                continue;
+            }
+        }
         fpga_data->i2c_adapter[portid_count] = phalanx_i2c_init(pdev, portid_count, VIRTUAL_I2C_BUS_OFFSET);
     }
 
@@ -2393,10 +2415,6 @@ static int phalanx_drv_probe(struct platform_device *pdev)
 #ifdef TEST_MODE
     return 0;
 #endif
-    fpga_i2c_access(fpga_data->i2c_adapter[FAN_I2C_CPLD_INDEX], FAN_CPLD_SLAVE_ADDR, 0x00,
-                    I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&fan_cpld_version);
-    fpga_i2c_access(fpga_data->i2c_adapter[BB_I2C_CPLD_INDEX], BB_CPLD_SLAVE_ADDR, 0x00,
-                    I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&bb_cpld_version);
     fpga_i2c_access(fpga_data->i2c_adapter[SW1_I2C_CPLD_INDEX], CPLD1_SLAVE_ADDR, 0x00,
                     I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&cpld1_version);
     fpga_i2c_access(fpga_data->i2c_adapter[SW1_I2C_CPLD_INDEX], CPLD2_SLAVE_ADDR, 0x00,
@@ -2406,8 +2424,6 @@ static int phalanx_drv_probe(struct platform_device *pdev)
     fpga_i2c_access(fpga_data->i2c_adapter[SW2_I2C_CPLD_INDEX], CPLD2_SLAVE_ADDR, 0x00,
                     I2C_SMBUS_READ, 0x00, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&cpld4_version);
 
-    printk(KERN_INFO "Fan CPLD Version: %2.2x\n", cpld1_version);
-    printk(KERN_INFO "BaseBoard CPLD Version: %2.2x\n", cpld2_version);
     printk(KERN_INFO "Switch CPLD1 Version: %2.2x\n", cpld1_version);
     printk(KERN_INFO "Switch CPLD2 Version: %2.2x\n", cpld2_version);
     printk(KERN_INFO "Switch CPLD3 Version: %2.2x\n", cpld3_version);
@@ -2416,6 +2432,12 @@ static int phalanx_drv_probe(struct platform_device *pdev)
 
     /* Init I2C buses that has PCA9548 switch device. */
     for (portid_count = 0; portid_count < VIRTUAL_I2C_PORT_LENGTH; portid_count++) {
+
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < SW1_I2C_CPLD_INDEX ){
+                continue;
+            }
+        }
 
         struct i2c_dev_data *dev_data;
         unsigned char master_bus;
@@ -2457,6 +2479,11 @@ static int phalanx_drv_remove(struct platform_device *pdev)
     }
 
     for (portid_count = I2C_MASTER_CH_1; portid_count <= I2C_MASTER_CH_TOTAL; portid_count++){
+        if(!allow_unsafe_i2c_access){
+            if( portid_count < I2C_MASTER_CH_7 ||  
+                portid_count == I2C_MASTER_CH_9 || portid_count == I2C_MASTER_CH_10 )
+                continue;
+        }
         i2c_core_deinit(portid_count, fpga_dev.data_base_addr);
     }
 
@@ -2721,6 +2748,9 @@ void phalanx_exit(void)
 
 module_init(phalanx_init);
 module_exit(phalanx_exit);
+
+module_param(allow_unsafe_i2c_access, bool, 0400);
+MODULE_PARM_DESC(allow_unsafe_i2c_access, "enable i2c busses despite potential races against BMC bus access");
 
 MODULE_AUTHOR("Pradchaya P. <pphuchar@celestica.com>");
 MODULE_DESCRIPTION("Celestica phalanx switchboard platform driver");

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -2383,7 +2383,7 @@ static int phalanx_drv_probe(struct platform_device *pdev)
 
     for (portid_count = 0 ; portid_count < VIRTUAL_I2C_PORT_LENGTH ; portid_count++) {
         if(!allow_unsafe_i2c_access){
-            if( portid_count < SW1_I2C_CPLD_INDEX ){
+            if( portid_count >= FAN_I2C_CPLD_INDEX && portid_count < SW1_I2C_CPLD_INDEX ){
                 fpga_data->i2c_adapter[portid_count] = NULL;
                 continue;
             }
@@ -2434,7 +2434,7 @@ static int phalanx_drv_probe(struct platform_device *pdev)
     for (portid_count = 0; portid_count < VIRTUAL_I2C_PORT_LENGTH; portid_count++) {
 
         if(!allow_unsafe_i2c_access){
-            if( portid_count < SW1_I2C_CPLD_INDEX ){
+            if( portid_count >= FAN_I2C_CPLD_INDEX && portid_count < SW1_I2C_CPLD_INDEX ){
                 continue;
             }
         }


### PR DESCRIPTION
Some I2C busses always occupied by BMC, these busses should not be accessed by SONiC.
In diagnostic sometimes they need to be accessed.
To do this add kernel module option to enable unsafe access to I2C busses when needed.