### PR TITLE
[platform/braodcom] Alibaba - Add mc24lc64t in platform init script.

### DIFF
--- a/debian/platform-modules-fishbone32.init
+++ b/debian/platform-modules-fishbone32.init
@@ -21,6 +21,7 @@ start)
         modprobe i2c-dev
         modprobe baseboard_cpld
         modprobe switchboard_fpga
+        modprobe mc24lt64t
         
         # Add driver to support TLV - EEPROM
         echo 24lc64t 0x56 > /sys/bus/i2c/devices/i2c-0/new_device

--- a/debian/platform-modules-fishbone48.init
+++ b/debian/platform-modules-fishbone48.init
@@ -21,9 +21,12 @@ start)
         modprobe i2c-imc allow_unsafe_access=1
         modprobe baseboard_cpld
         modprobe switchboard_fpga
+        modprobe mc24lc64t
 
         # Add driver to support TLV - EEPROM
         echo 24lc64t 0x56 > /sys/bus/i2c/devices/i2c-0/new_device
+
+        echo "done."
         ;;
 
 stop)

--- a/debian/platform-modules-phalanx.init
+++ b/debian/platform-modules-phalanx.init
@@ -21,6 +21,7 @@ start)
         modprobe i2c-imc allow_unsafe_access=1
         modprobe baseboard_cpld
         modprobe switchboard_fpga
+        modprobe mc24lt64t
         
         # Add driver to support TLV - EEPROM
         echo 24lc64t 0x56 > /sys/bus/i2c/devices/i2c-0/new_device


### PR DESCRIPTION
 *Add mc24lc64t driver probe before instantiating new i2c device on Fishbones48, Fishbone32, and Phalanx platform.
Issue #30 

**Need to build and test before accept merge.**