### PR TITLE
Alibaba - fix switchboard driver auto probe fail bug.

### DIFF
--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -2239,6 +2239,7 @@ int fishbone32_init(void)
     if (rc)
         return rc;
     if (fpga_dev.data_base_addr == NULL) {
+        pci_unregister_driver(&pci_dev_ops);
         printk(KERN_ALERT "FPGA PCIe device not found!\n");
         return -ENODEV;
     }

--- a/fishbone48/modules/switchboard_fpga.c
+++ b/fishbone48/modules/switchboard_fpga.c
@@ -2306,6 +2306,7 @@ int fishbone48_init(void)
     if (rc)
         return rc;
     if (fpga_dev.data_base_addr == NULL) {
+        pci_unregister_driver(&pci_dev_ops);
         printk(KERN_ALERT "FPGA PCIe device not found!\n");
         return -ENODEV;
     }

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -2789,6 +2789,7 @@ int phalanx_init(void)
     if (rc)
         return rc;
     if (fpga_dev.data_base_addr == NULL) {
+        pci_unregister_driver(&pci_dev_ops);
         printk(KERN_ALERT "FPGA PCIe device not found!\n");
         return -ENODEV;
     }


### PR DESCRIPTION
This fix the bug when PCI device added and the kernel auto probe was enabled.
 - The driver part will be removed when module probe fails.