### PR TITLE
[platform/broadcom] Use systemd to load platform services

### DIFF
--- a/debian/platform-modules-fishbone32.install
+++ b/debian/platform-modules-fishbone32.install
@@ -1,4 +1,5 @@
 fishbone32/cfg/fishbone32-modules.conf etc/modules-load.d
+fishbone32/systemd/platform-modules-fishbone32.service lib/systemd/system
 tools/sync_bmc/bmc_vlan.service etc/systemd/system
 tools/sync_bmc/sync_bmc.service etc/systemd/system
 tools/sync_bmc/sync_bmc.timer etc/systemd/system

--- a/debian/platform-modules-fishbone32.postinst
+++ b/debian/platform-modules-fishbone32.postinst
@@ -3,8 +3,8 @@ depmod -a
 # Enable bmc vlan_ip service
 systemctl enable bmc_vlan.service
 
-update-rc.d platform-modules-fishbone32 defaults
-service platform-modules-fishbone32 start
+systemctl enable platform-modules-fishbone32.service
+systemctl start platform-modules-fishbone32.service
 
 # Enable platform-sync_bmc-timer
 # systemctl enable sync_bmc.timer

--- a/debian/platform-modules-fishbone48.install
+++ b/debian/platform-modules-fishbone48.install
@@ -1,4 +1,5 @@
 fishbone48/cfg/fishbone48-modules.conf etc/modules-load.d
+fishbone48/systemd/platform-modules-fishbone48.service lib/systemd/system
 tools/sync_bmc/bmc_vlan.service etc/systemd/system
 tools/sync_bmc/sync_bmc.service etc/systemd/system
 tools/sync_bmc/sync_bmc.timer etc/systemd/system

--- a/debian/platform-modules-fishbone48.postinst
+++ b/debian/platform-modules-fishbone48.postinst
@@ -3,8 +3,8 @@ depmod -a
 # Enable bmc vlan_ip service
 systemctl enable bmc_vlan.service
 
-update-rc.d platform-modules-fishbone48 defaults
-service platform-modules-fishbone48 start
+systemctl enable platform-modules-fishbone48.service
+systemctl start platform-modules-fishbone48.service
 
 # Enable platform-sync_bmc-timer
 # systemctl enable sync_bmc.timer

--- a/debian/platform-modules-phalanx.install
+++ b/debian/platform-modules-phalanx.install
@@ -1,4 +1,5 @@
 phalanx/cfg/phalanx-modules.conf etc/modules-load.d
+phalanx/systemd/platform-modules-phalanx.service lib/systemd/system
 tools/sync_bmc/bmc_vlan.service etc/systemd/system
 tools/sync_bmc/sync_bmc.service etc/systemd/system
 tools/sync_bmc/sync_bmc.timer etc/systemd/system

--- a/debian/platform-modules-phalanx.postinst
+++ b/debian/platform-modules-phalanx.postinst
@@ -3,8 +3,8 @@ depmod -a
 # Enable bmc vlan_ip service
 systemctl enable bmc_vlan.service
 
-update-rc.d platform-modules-phalanx defaults
-service platform-modules-phalanx start
+systemctl enable platform-modules-phalanx.service
+systemctl start platform-modules-phalanx.service
 
 # Enable platform-sync_bmc-timer
 # systemctl enable sync_bmc.timer

--- a/fishbone32/systemd/platform-modules-fishbone32.service
+++ b/fishbone32/systemd/platform-modules-fishbone32.service
@@ -1,0 +1,14 @@
+
+[Unit]
+Description=Celestica Fishbone32 platform modules
+After=local-fs.target
+Before=pmon.service
+
+[Service]
+Type=oneshot
+ExecStart=-/etc/init.d/platform-modules-fishbone32 start
+ExecStop=-/etc/init.d/platform-modules-fishbone32 stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/fishbone48/systemd/platform-modules-fishbone48.service
+++ b/fishbone48/systemd/platform-modules-fishbone48.service
@@ -1,0 +1,14 @@
+
+[Unit]
+Description=Celestica Fishbone48 platform modules
+After=local-fs.target
+Before=pmon.service
+
+[Service]
+Type=oneshot
+ExecStart=-/etc/init.d/platform-modules-fishbone48 start
+ExecStop=-/etc/init.d/platform-modules-fishbone48 stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/phalanx/systemd/platform-modules-phalanx.service
+++ b/phalanx/systemd/platform-modules-phalanx.service
@@ -1,0 +1,14 @@
+
+[Unit]
+Description=Celestica Phalanx platform modules
+After=local-fs.target
+Before=pmon.service
+
+[Service]
+Type=oneshot
+ExecStart=-/etc/init.d/platform-modules-phalanx start
+ExecStop=-/etc/init.d/platform-modules-phalanx stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**What I did?**
Fix the platform module does not load when OS start.
**How I did it?**
Add the systemd unit file to platform-module-cel package and enable the service in post install script.
**How to verify?**
After the system boot up, the platform module must load autometically.