### PR TITLE
[phalanx/fishbone] Fix fault alert message when insert kernel module

### DIFF
--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.3.1"
+#define MOD_VERSION "0.3.2"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -2572,6 +2572,14 @@ static int phalanx_drv_remove(struct platform_device *pdev)
     return 0;
 }
 
+static struct platform_driver phalanx_drv = {
+    .probe  = phalanx_drv_probe,
+    .remove = __exit_p(phalanx_drv_remove),
+    .driver = {
+        .name   = DRIVER_NAME,
+    },
+};
+
 #ifdef TEST_MODE
 #define FPGA_PCI_BAR_NUM 2
 #else
@@ -2629,6 +2637,8 @@ static int fpga_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
     fpga_version = ioread32(fpga_dev.data_base_addr);
     printk(KERN_INFO "FPGA Version : %8.8x\n", fpga_version);
     fpgafw_init();
+    platform_device_register(&phalanx_dev);
+    platform_driver_register(&phalanx_drv);
     return 0;
 
 pci_release:
@@ -2640,6 +2650,8 @@ pci_disable:
 
 static void fpga_pci_remove(struct pci_dev *pdev)
 {
+    platform_driver_unregister(&phalanx_drv);
+    platform_device_unregister(&phalanx_dev);
     fpgafw_exit();
     pci_iounmap(pdev, fpga_dev.data_base_addr);
     pci_release_regions(pdev);
@@ -2652,15 +2664,6 @@ static struct pci_driver pci_dev_ops = {
     .probe      = fpga_pci_probe,
     .remove     = fpga_pci_remove,
     .id_table   = fpga_id_table,
-};
-
-
-static struct platform_driver phalanx_drv = {
-    .probe  = phalanx_drv_probe,
-    .remove = __exit_p(phalanx_drv_remove),
-    .driver = {
-        .name   = DRIVER_NAME,
-    },
 };
 
 enum {
@@ -2788,20 +2791,11 @@ int phalanx_init(void)
     rc = pci_register_driver(&pci_dev_ops);
     if (rc)
         return rc;
-    if (fpga_dev.data_base_addr == NULL) {
-        pci_unregister_driver(&pci_dev_ops);
-        printk(KERN_ALERT "FPGA PCIe device not found!\n");
-        return -ENODEV;
-    }
-    platform_device_register(&phalanx_dev);
-    platform_driver_register(&phalanx_drv);
     return 0;
 }
 
 void phalanx_exit(void)
 {
-    platform_driver_unregister(&phalanx_drv);
-    platform_device_unregister(&phalanx_dev);
     pci_unregister_driver(&pci_dev_ops);
 }
 


### PR DESCRIPTION
__What I did?__
Fix the fault alert kernel message, when rescanning FPGA device.
__How I did?__
Update the device driver probe sequence after kernel module added. This will fix the fault alert message about FPGA device not found in the debug message.