### PR TITLE
[Phalanx/Fishbone32] Add workaround for EEPROM for write FF issue

### DIFF
--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.1"
+#define MOD_VERSION "0.5.2"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -1134,9 +1134,13 @@ static int i2c_core_init(unsigned int master_bus, unsigned int freq_div,void __i
 
     // Makes sure core is disable
     ctrl = ioread8(pci_bar + REG_CTRL);
-    iowrite8( ctrl & ~(1 << I2C_CTRL_EN), pci_bar + REG_CTRL);
+    iowrite8( ctrl & ~(1 << I2C_CTRL_EN | 1 << I2C_CTRL_IEN), pci_bar + REG_CTRL);
+
     iowrite8( freq_div & 0xFF , pci_bar + REG_FREQ_L);
     iowrite8( freq_div >> 8, pci_bar + REG_FREQ_H);
+
+    /* Only enable EN bit, we only use polling mode */
+    iowrite8(1 << I2C_CMD_IACK, pci_bar + REG_CMD);
     iowrite8(1 << I2C_CTRL_EN, pci_bar + REG_CTRL);
 
     return 0;
@@ -1147,7 +1151,7 @@ static void i2c_core_deinit(unsigned int master_bus,void __iomem *pci_bar){
     unsigned int REG_CTRL;
     REG_CTRL = I2C_MASTER_CTRL + (master_bus - 1) * 0x20;
     // Disable core
-    iowrite8( ioread8(pci_bar + REG_CTRL) & ~(1 << I2C_CTRL_EN), pci_bar + REG_CTRL);
+    iowrite8( ioread8(pci_bar + REG_CTRL) & ~(1 << I2C_CTRL_EN| 1 << I2C_CTRL_IEN), pci_bar + REG_CTRL);
 }
 
 //FIXME: The hard code seperater below will causing bug!
@@ -1212,15 +1216,22 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     check(pci_bar + REG_STAT);
     check(pci_bar + REG_CTRL);
 
-    dev_dbg(&a->dev,"ST:%2.2X\n", ioread8(pci_bar + REG_STAT));
+    /*
+     * We wait for the data to be transferred (8bit),
+     * then we start polling on the ACK/NACK bit
+     * udelay((8 * 1000) / 100);
+     */
+    udelay(80);
+    dev_dbg(&a->dev,"Wait for 0x%2.2X\n", 1 << I2C_STAT_TIP);
+
     timeout = jiffies + msecs_to_jiffies(timeout);
     while (1) {
         Status = ioread8(pci_bar + REG_STAT);
-        dev_dbg(&a->dev,"ST:%2.2X\n", Status);
+        dev_dbg(&a->dev, "ST:%2.2X\n", Status);
 
-        if ( (Status & ( 1 << I2C_STAT_TIP ))  == 0 ) 
-        {
-            dev_dbg(&a->dev,"  ST:%2.2X\n", Status);
+        /* Wait for the TIP bit to be cleared before timeout */
+        if ( (Status & ( 1 << I2C_STAT_TIP ))  == 0 ) {
+            dev_dbg(&a->dev, "  TIP cleared:0x%2.2X\n", Status);
             break;
         }
 
@@ -1238,8 +1249,8 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     info("STA:%x",Status);
 
     if (error < 0) {
-        info("Status %2.2X", Status);
-
+        dev_dbg(&a->dev, "%s TIMEOUT bit 0x%x not clear in specific time\n",
+                 __func__, (1 << I2C_STAT_TIP));
         return error;
     }
 
@@ -1300,22 +1311,21 @@ static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writi
     check(pci_bar + REG_STAT);
     check(pci_bar + REG_CTRL);
 
-    dev_dbg(&a->dev,"ST:%2.2X\n", ioread8(pci_bar + REG_STAT));
+    dev_dbg(&a->dev,"Wait for 0x%2.2X\n", 1 << I2C_STAT_BUSY);
     timeout = jiffies + msecs_to_jiffies(timeout);
     while (1) {
         Status = ioread8(pci_bar + REG_STAT);
-        dev_dbg(&a->dev,"ST:%2.2X\n", Status);
+        dev_dbg(&a->dev, "ST:%2.2X\n", Status);
         if (time_after(jiffies, timeout)) {
             info("Status %2.2X", Status);
             info("Error Timeout");
             error = -ETIMEDOUT;
             break;
         }
-        // In STOP state, we wait for busy to be cleared
-        // So we know the STOP was sent successfully.
-        if ( (Status & ( 1 << I2C_STAT_BUSY ))  == 0 ) 
-        {
-            dev_dbg(&a->dev,"  IF:%2.2X\n", Status);
+
+        /* Wait for the BUSY bit to be cleared before timeout */
+        if ( (Status & ( 1 << I2C_STAT_BUSY ))  == 0 ) {
+            dev_dbg(&a->dev, "  BUSY cleared:0x%2.2X\n", Status);
             break;
         }
 
@@ -1326,7 +1336,8 @@ static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writi
     info("STA:%x",Status);
 
     if (error < 0) {
-        info("Status %2.2X", Status);
+        dev_dbg(&a->dev, "%s TIMEOUT bit 0x%x not clear in specific time\n",
+                 __func__, (1 << I2C_STAT_BUSY));
         return error;
     }
     return 0;
@@ -1344,6 +1355,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
     struct i2c_dev_data *dev_data;
     void __iomem *pci_bar;
     unsigned int  portid, master_bus;
+    int error_stop = 0;
 
     unsigned int REG_FREQ_L;
     unsigned int REG_FREQ_H;
@@ -1418,7 +1430,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         // sent device address with Write mode
         iowrite8( (addr << 1) & 0xFE, pci_bar + REG_DATA);
     }
-    iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR, pci_bar + REG_CMD);
+    iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
 
     info( "MS Start");
 
@@ -1441,7 +1453,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         // sent command code to data register
         iowrite8(cmd, pci_bar + REG_DATA);
         // Start the transfer
-        iowrite8(1 << I2C_CMD_WR, pci_bar + REG_CMD);
+        iowrite8(1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
         info( "MS Send CMD 0x%2.2X", cmd);
 
         // Wait {A}
@@ -1473,7 +1485,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
 
         iowrite8(cnt, pci_bar + REG_DATA);
         //Start the transfer
-        iowrite8(1 << I2C_CMD_WR, pci_bar + REG_CMD);
+        iowrite8(1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
         info( "MS Send CNT 0x%2.2X", cnt);
 
         // Wait {A}
@@ -1504,7 +1516,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
             info("STA:%x", ioread8(pci_bar + REG_STAT) );
             info( "   Data > %2.2X", data->block[bid]);
             iowrite8(data->block[bid], pci_bar + REG_DATA);
-            iowrite8(1 << I2C_CMD_WR, pci_bar + REG_CMD);
+            iowrite8(1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
 
             // Wait {A}
             // IACK
@@ -1528,7 +1540,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         // sent Address with Read mode
         iowrite8( addr << 1 | 0x1 , pci_bar + REG_DATA);
         // SET START | WRITE
-        iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR, pci_bar + REG_CMD);
+        iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
 
         // Wait {A}
         error = i2c_wait_ack(adapter, 30, 1);
@@ -1569,7 +1581,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
             // Start receive FSM
             if (bid == cnt - 1) {
                 info( "READ NACK");
-                iowrite8(1 << I2C_CMD_RD | 1 << I2C_CMD_ACK, pci_bar + REG_CMD);
+                iowrite8(1 << I2C_CMD_RD | 1 << I2C_CMD_ACK | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
             }else{
 
                 iowrite8(1 << I2C_CMD_RD, pci_bar + REG_CMD);
@@ -1602,9 +1614,12 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
 Done:
     info( "MS STOP");
     // SET STOP
-    iowrite8( 1 << I2C_CMD_STO, pci_bar + REG_CMD);
+    iowrite8( 1 << I2C_CMD_STO | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
     // Wait for the STO to finish.
-    i2c_wait_stop(adapter, 30, 0);
+    error_stop = i2c_wait_stop(adapter, 30, 0);
+    if (error_stop < 0) {
+        dev_dbg(&adapter->dev,"STOP Error: %d\n", error_stop);
+    }
     check(pci_bar + REG_CTRL);
     check(pci_bar + REG_STAT);
 #ifdef DEBUG_KERN

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -23,7 +23,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.4.0"
+#define MOD_VERSION "0.5.0"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -362,6 +362,8 @@ static struct device* fpgafwdev = NULL;    // < The device-driver device struct 
 static struct mutex fpga_i2c_master_locks[I2C_MASTER_CH_TOTAL];
 /* Store lasted switch address and channel */
 static uint16_t fpga_i2c_lasted_access_port[I2C_MASTER_CH_TOTAL];
+static int nack_retry[I2C_MASTER_CH_TOTAL];
+static int need_retry[I2C_MASTER_CH_TOTAL];
 
 enum PORT_TYPE {
     NONE,
@@ -1519,11 +1521,10 @@ static int i2c_core_init(unsigned int master_bus, unsigned int freq_div,void __i
 
     // Makes sure core is disable
     ctrl = ioread8(pci_bar + REG_CTRL);
-    iowrite8( ctrl & ~(1 << I2C_CTRL_EN | 1 << I2C_CTRL_IEN), pci_bar + REG_CTRL);
+    iowrite8( ctrl & ~(1 << I2C_CTRL_EN), pci_bar + REG_CTRL);
     iowrite8( freq_div & 0xFF , pci_bar + REG_FREQ_L);
     iowrite8( freq_div >> 8, pci_bar + REG_FREQ_H);
-    iowrite8(1 << I2C_CMD_IACK, pci_bar + REG_CMD);
-    iowrite8(1 << I2C_CTRL_EN | 1 << I2C_CTRL_IEN, pci_bar + REG_CTRL);
+    iowrite8(1 << I2C_CTRL_EN, pci_bar + REG_CTRL);
 
     return 0;
 }
@@ -1533,7 +1534,7 @@ static void i2c_core_deinit(unsigned int master_bus,void __iomem *pci_bar){
     unsigned int REG_CTRL;
     REG_CTRL = I2C_MASTER_CTRL + (master_bus - 1) * 0x20;
     // Disable core
-    iowrite8( ioread8(pci_bar + REG_CTRL) & ~(1 << I2C_CTRL_EN| 1 << I2C_CTRL_IEN), pci_bar + REG_CTRL);
+    iowrite8( ioread8(pci_bar + REG_CTRL) & ~(1 << I2C_CTRL_EN), pci_bar + REG_CTRL);
 }
 
 /**
@@ -1638,23 +1639,29 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     while (1) {
         Status = ioread8(pci_bar + REG_STAT);
         dev_dbg(&a->dev,"ST:%2.2X\n", Status);
-        if (jiffies > timeout) {
+
+        if ( (Status & ( 1 << I2C_STAT_TIP ))  == 0 ) 
+        {
+            dev_dbg(&a->dev,"  ST:%2.2X\n", Status);
+            break;
+        }
+
+        if (time_after(jiffies, timeout)) {
             info("Status %2.2X", Status);
             info("Error Timeout");
             error = -ETIMEDOUT;
             break;
         }
 
-        if ( Status & ( 1 << I2C_STAT_IF ) ) {
-            dev_dbg(&a->dev,"  IF:%2.2X\n", Status);
-            break;
-        }
+        cpu_relax();
+        cond_resched();
     }
     info("Status %2.2X", Status);
     info("STA:%x",Status);
 
     if (error < 0) {
         info("Status %2.2X", Status);
+
         return error;
     }
 
@@ -1665,6 +1672,7 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     // Arbitration lost
     if (Status & (1 << I2C_STAT_AL)) {
         info("Error arbitration lost");
+        nack_retry[master_bus - 1] = 1;
         return -EBUSY;
     }
 
@@ -1673,10 +1681,75 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
         info( "SL No ACK");
         if (writing) {
             info("Error No ACK");
+            nack_retry[master_bus - 1] = 1;
             return -EIO;
         }
     } else {
         info( "SL ACK");
+    }
+
+    return error;
+}
+
+static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writing) {
+    int error = 0;
+    int Status;
+
+    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    void __iomem *pci_bar = fpga_dev.data_base_addr;
+
+    unsigned int REG_FREQ_L;
+    unsigned int REG_FREQ_H;
+    unsigned int REG_CMD;
+    unsigned int REG_CTRL;
+    unsigned int REG_STAT;
+    unsigned int REG_DATA;
+
+    unsigned int master_bus = new_data->pca9548.master_bus;
+
+    if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
+        error = -EINVAL;
+        return error;
+    }
+
+    REG_FREQ_L = I2C_MASTER_FREQ_L  + (master_bus - 1) * 0x20;
+    REG_FREQ_H = I2C_MASTER_FREQ_H  + (master_bus - 1) * 0x20;
+    REG_CTRL   = I2C_MASTER_CTRL    + (master_bus - 1) * 0x20;
+    REG_CMD    = I2C_MASTER_CMD     + (master_bus - 1) * 0x20;
+    REG_STAT   = I2C_MASTER_STATUS  + (master_bus - 1) * 0x20;
+    REG_DATA   = I2C_MASTER_DATA    + (master_bus - 1) * 0x20;
+
+    check(pci_bar + REG_STAT);
+    check(pci_bar + REG_CTRL);
+
+    dev_dbg(&a->dev,"ST:%2.2X\n", ioread8(pci_bar + REG_STAT));
+    timeout = jiffies + msecs_to_jiffies(timeout);
+    while (1) {
+        Status = ioread8(pci_bar + REG_STAT);
+        dev_dbg(&a->dev,"ST:%2.2X\n", Status);
+        if (time_after(jiffies, timeout)) {
+            info("Status %2.2X", Status);
+            info("Error Timeout");
+            error = -ETIMEDOUT;
+            break;
+        }
+        // In STOP state, we wait for busy to be cleared
+        // So we know the STOP was sent successfully.
+        if ( (Status & ( 1 << I2C_STAT_BUSY ))  == 0 ) 
+        {
+            dev_dbg(&a->dev,"  IF:%2.2X\n", Status);
+            break;
+        }
+
+        cpu_relax();
+        cond_resched();
+    }
+    info("Status %2.2X", Status);
+    info("STA:%x",Status);
+
+    if (error < 0) {
+        info("Status %2.2X", Status);
+        return error;
     }
     return 0;
 }
@@ -1725,6 +1798,10 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
            size == 8 ? "I2C_BLOCK_DATA" :  "ERROR"
            , cmd);
 #endif
+
+    master_bus = dev_data->pca9548.master_bus;
+    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
+
     /* Map the size to what the chip understands */
     switch (size) {
     case I2C_SMBUS_QUICK:
@@ -1763,7 +1840,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         // sent device address with Write mode
         iowrite8( (addr << 1) & 0xFE, pci_bar + REG_DATA);
     }
-    iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
+    iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR, pci_bar + REG_CMD);
 
     info( "MS Start");
 
@@ -1786,7 +1863,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         // sent command code to data register
         iowrite8(cmd, pci_bar + REG_DATA);
         // Start the transfer
-        iowrite8(1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
+        iowrite8(1 << I2C_CMD_WR, pci_bar + REG_CMD);
         info( "MS Send CMD 0x%2.2X", cmd);
 
         // Wait {A}
@@ -1818,7 +1895,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
 
         iowrite8(cnt, pci_bar + REG_DATA);
         //Start the transfer
-        iowrite8(1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
+        iowrite8(1 << I2C_CMD_WR, pci_bar + REG_CMD);
         info( "MS Send CNT 0x%2.2X", cnt);
 
         // Wait {A}
@@ -1849,7 +1926,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
             info("STA:%x", ioread8(pci_bar + REG_STAT) );
             info( "   Data > %2.2X", data->block[bid]);
             iowrite8(data->block[bid], pci_bar + REG_DATA);
-            iowrite8(1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
+            iowrite8(1 << I2C_CMD_WR, pci_bar + REG_CMD);
 
             // Wait {A}
             // IACK
@@ -1873,7 +1950,7 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         // sent Address with Read mode
         iowrite8( addr << 1 | 0x1 , pci_bar + REG_DATA);
         // SET START | WRITE
-        iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
+        iowrite8( 1 << I2C_CMD_STA | 1 << I2C_CMD_WR, pci_bar + REG_CMD);
 
         // Wait {A}
         error = i2c_wait_ack(adapter, 30, 1);
@@ -1914,14 +1991,18 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
             // Start receive FSM
             if (bid == cnt - 1) {
                 info( "READ NACK");
-                iowrite8(1 << I2C_CMD_RD | 1 << I2C_CMD_ACK | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
+                iowrite8(1 << I2C_CMD_RD | 1 << I2C_CMD_ACK, pci_bar + REG_CMD);
             }else{
 
-                iowrite8(1 << I2C_CMD_RD | 1 << I2C_CMD_IACK , pci_bar + REG_CMD);
+                iowrite8(1 << I2C_CMD_RD, pci_bar + REG_CMD);
             }
             
             // Wait {A}
             error = i2c_wait_ack(adapter, 30, 0);
+            if(nack_retry[master_bus - 1] == 1)
+            {
+                need_retry[master_bus - 1] = 1;
+            }
             if (error < 0) {
                 dev_dbg(&adapter->dev,"Receive DATA Error: %d\n", error);
                 goto Done;
@@ -1943,9 +2024,9 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
 Done:
     info( "MS STOP");
     // SET STOP
-    iowrite8( 1 << I2C_CMD_STO | 1 << I2C_CMD_IACK, pci_bar + REG_CMD);
-    // Polling for the STO to finish.
-    i2c_wait_ack(adapter, 30, 0);
+    iowrite8( 1 << I2C_CMD_STO, pci_bar + REG_CMD);
+    // Wait for the STO to finish.
+    i2c_wait_stop(adapter, 30, 0);
     check(pci_bar + REG_CTRL);
     check(pci_bar + REG_STAT);
 #ifdef DEBUG_KERN
@@ -1993,7 +2074,9 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
 
     if (switch_addr != 0xFF) {
 
+
         // Check lasted access switch address on a master
+        // Only select new channel of a switch if they are difference from last channel of a switch
         if ( prev_switch != switch_addr && prev_switch != 0 ) {
             // reset prev_port PCA9548 chip
             retry = 3;
@@ -2016,7 +2099,7 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
                 if(error >= 0){
                     break;
                 }else{
-                    dev_dbg(&adapter->dev,"Failed to deselect ch %d of 0x%x, CODE %d\n", prev_ch, prev_switch, error);
+                    dev_dbg(&adapter->dev,"Failed to select ch %d of 0x%x, CODE %d\n", prev_ch, prev_switch, error);
                 }
 
             }
@@ -2036,7 +2119,7 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
                     if(error >= 0){
                         break;
                     }else{
-                    dev_dbg(&adapter->dev,"Failed to deselect ch %d of 0x%x, CODE %d\n", prev_ch, prev_switch, error);
+                    dev_dbg(&adapter->dev,"Failed to select ch %d of 0x%x, CODE %d\n", prev_ch, prev_switch, error);
                     }
 
                 }
@@ -2050,17 +2133,24 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
     }
 
     // Do SMBus communication
+    nack_retry[master_bus - 1] = 0;
+    need_retry[master_bus - 1] = 0;
     error = smbus_access(adapter, addr, flags, rw, cmd, size, data);
-    if(error == -EBUSY){
+    if((nack_retry[master_bus - 1]==1)&&(need_retry[master_bus - 1]==1))
+        retry = 2000;
+    else
         retry = 5;
-    }
     // If the first access failed, do retry.
-    while( (error < 0)  && retry){
+    while((nack_retry[master_bus - 1]==1)&&retry)
+    {
         retry--;
+        nack_retry[master_bus - 1] = 0;
         dev_dbg(&adapter->dev,"error = %d\n",error);
         error = smbus_access(adapter, addr, flags, rw, cmd, size, data);
         dev_dbg(&adapter->dev,"nack retry = %d\n",retry);
     }
+    nack_retry[master_bus - 1] = 0;
+    need_retry[master_bus - 1] = 0;
 
     retval = error;
 
@@ -2697,7 +2787,7 @@ static int fpga_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
     /* bar0: data mmio region */
     fpga_dev.data_mmio_start = pci_resource_start(pdev, FPGA_PCI_BAR_NUM);
     fpga_dev.data_mmio_len = pci_resource_len(pdev, FPGA_PCI_BAR_NUM);
-    fpga_dev.data_base_addr = pci_iomap(pdev, FPGA_PCI_BAR_NUM, 0);
+    fpga_dev.data_base_addr = ioremap_nocache(fpga_dev.data_mmio_start, fpga_dev.data_mmio_len);
     if (!fpga_dev.data_base_addr) {
         dev_err(dev, "cannot iomap region of size %lu\n",
                 (unsigned long)fpga_dev.data_mmio_len);


### PR DESCRIPTION
The change will add the following changes to i2c adapter driver to fix the write 0xFF issue in the optical module EEPROM. 

__Modules:__ I2C adapter driver
__Platforms:__ Phalanx, Fishbone32
__Changes__:
 1. Apply clock stretching workaround.
 2. Add Interrupt acknowledge (IACK) back when issue command to CMD register.
 1. Add 8 clocks delay before start polling TIP bit in STATUS register.