### PR TITLE
[Phalanx/Fishbones][BSP] Fix port xcvr status race condition

### DIFF
--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.2"
+#define MOD_VERSION "0.5.3"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -426,6 +426,7 @@ static struct i2c_switch fpga_i2c_bus_dev[] = {
 #define FAN_I2C_CPLD_INDEX      SFF_PORT_TOTAL
 #define BB_I2C_CPLD_INDEX       SFF_PORT_TOTAL + 4
 #define SW_I2C_CPLD_INDEX       SFF_PORT_TOTAL + 6
+#define NUM_SWITCH_CPLDS        2
 
 struct fpga_device {
     /* data mmio region */
@@ -440,11 +441,26 @@ static struct fpga_device fpga_dev = {
     .data_mmio_len = 0,
 };
 
+/*
+ * struct fishbone32_fpga_data - Private data for fishbone32 switchboard driver.
+ * @sff_device:         List of optical module device node.
+ * @i2c_client:         List of optical module I2C client device.
+ * @i2c_adapter:        List of I2C adapter populates by this driver.
+ * @fpga_lock:          FPGA internal locks for register access.
+ * @sw_cpld_locks:      Switch CPLD xcvr resource lock.
+ * @fpga_read_addr:     Buffer point to FPGA's register.
+ * @cpld1_read_addr:    Buffer point to CPLD1's register.
+ * @cpld2_read_addr:    Buffer point to CPLD2's register.
+ *
+ * For *_read_addr, its temporary hold the register address to be read by
+ * getreg sysfs, see *getreg() for more details.
+ */
 struct fishbone32_fpga_data {
     struct device *sff_devices[SFF_PORT_TOTAL];
     struct i2c_client *sff_i2c_clients[SFF_PORT_TOTAL];
     struct i2c_adapter *i2c_adapter[VIRTUAL_I2C_PORT_LENGTH];
-    struct mutex fpga_lock;         // For FPGA internal lock
+    struct mutex fpga_lock;
+    struct mutex sw_cpld_locks[NUM_SWITCH_CPLDS];
     void __iomem * fpga_read_addr;
     uint8_t cpld1_read_addr;
     uint8_t cpld2_read_addr;
@@ -1154,35 +1170,69 @@ static void i2c_core_deinit(unsigned int master_bus,void __iomem *pci_bar){
     iowrite8( ioread8(pci_bar + REG_CTRL) & ~(1 << I2C_CTRL_EN| 1 << I2C_CTRL_IEN), pci_bar + REG_CTRL);
 }
 
-//FIXME: The hard code seperater below will causing bug!
-//Should pass configuration args into function.
+/*
+ * i2c_xcvr_access() - Optical port xcvr accessor through Switch CPLDs.
+ * @register_address: The xcvr register address.
+ * @portid:           Optical module port index, start from 1.
+ * @data:             Buffer to get or set data.
+ * @rw:               I2C_SMBUS_READ or I2C_SMBUS_WRITE flag.
+ *
+ * Fishbone32 have 2 switch CPLDs, Each CPLD manages 16 ports.
+ *
+ *  +------------------+------------------+
+ *  |1     CPLD1     15|17   CPLD2      31|
+ *  |2               16|18              32|
+ *  +------------------+------------------+
+ *
+ * Return: 0 if success, error code less than zero if fails.
+ */
 static int i2c_xcvr_access(u8 register_address, unsigned int portid, u8 *data, char rw){
     
     u16 dev_addr = 0;
     int err;
+    unsigned int sw_cpld_lock_index = 0;
+
     /* check for portid valid length */
     if(portid < 0 || portid > SFF_PORT_TOTAL){
         return -EINVAL;
     }
     if (portid <= 16 ){
         dev_addr = CPLD1_SLAVE_ADDR;
+        sw_cpld_lock_index = 0;
     }else{
         dev_addr = CPLD2_SLAVE_ADDR;
         portid = portid - 16;
+        sw_cpld_lock_index = 1;
     }
+
+    mutex_lock(&fpga_data->sw_cpld_locks[sw_cpld_lock_index]);
+
     // Select port
-    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], dev_addr, 0x00, I2C_SMBUS_WRITE, 
-        I2C_XCVR_SEL, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&portid);
+    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX],
+                          dev_addr,
+                          0x00,
+                          I2C_SMBUS_WRITE,
+                          I2C_XCVR_SEL,
+                          I2C_SMBUS_BYTE_DATA,
+                          (union i2c_smbus_data*)&portid);
     if(err < 0){
-        return err;
+        goto exit_unlock;
     }
     // Read/write port xcvr register
-    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], dev_addr, 0x00, rw, 
-        register_address , I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)data);
+    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX],
+                          dev_addr,
+                          0x00,
+                          rw,
+                          register_address,
+                          I2C_SMBUS_BYTE_DATA,
+                          (union i2c_smbus_data*)data);
     if(err < 0){
-        return err;
+        goto exit_unlock;
     }
-    return 0;
+
+exit_unlock:
+    mutex_unlock(&fpga_data->sw_cpld_locks[sw_cpld_lock_index]);
+    return err;
 }
 
 static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writing) {
@@ -1940,6 +1990,11 @@ static int fishbone32_drv_probe(struct platform_device *pdev)
     fpga_data->cpld2_read_addr = 0x00;
 
     mutex_init(&fpga_data->fpga_lock);
+
+    for (ret = 0; ret < NUM_SWITCH_CPLDS; ret++) {
+        mutex_init(&fpga_data->sw_cpld_locks[ret]);
+    }
+
     for (ret = I2C_MASTER_CH_1 ; ret <= I2C_MASTER_CH_TOTAL; ret++) {
         mutex_init(&fpga_i2c_master_locks[ret - 1]);
     }

--- a/fishbone48/modules/switchboard_fpga.c
+++ b/fishbone48/modules/switchboard_fpga.c
@@ -25,7 +25,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.0"
+#define MOD_VERSION "0.5.1"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -445,6 +445,7 @@ static struct i2c_switch fpga_i2c_bus_dev[] = {
 #define FAN_I2C_CPLD_INDEX      SFF_PORT_TOTAL
 #define BB_I2C_CPLD_INDEX       SFF_PORT_TOTAL + 4
 #define SW_I2C_CPLD_INDEX       SFF_PORT_TOTAL + 6
+#define NUM_SWITCH_CPLDS        2
 
 struct fpga_device {
     /* data mmio region */
@@ -459,11 +460,26 @@ static struct fpga_device fpga_dev = {
     .data_mmio_len = 0,
 };
 
+/*
+ * struct fishbone48_fpga_data - Private data for fishbone48 switchboard driver.
+ * @sff_device:         List of optical module device node.
+ * @i2c_client:         List of optical module I2C client device.
+ * @i2c_adapter:        List of I2C adapter populates by this driver.
+ * @fpga_lock:          FPGA internal locks for register access.
+ * @sw_cpld_locks:      Switch CPLD xcvr resource lock.
+ * @fpga_read_addr:     Buffer point to FPGA's register.
+ * @cpld1_read_addr:    Buffer point to CPLD1's register.
+ * @cpld2_read_addr:    Buffer point to CPLD2's register.
+ *
+ * For *_read_addr, its temporary hold the register address to be read by
+ * getreg sysfs, see *getreg() for more details.
+ */
 struct fishbone48_fpga_data {
     struct device *sff_devices[SFF_PORT_TOTAL];
     struct i2c_client *sff_i2c_clients[SFF_PORT_TOTAL];
     struct i2c_adapter *i2c_adapter[VIRTUAL_I2C_PORT_LENGTH];
-    struct mutex fpga_lock;         // For FPGA internal lock
+    struct mutex fpga_lock;
+    struct mutex sw_cpld_locks[NUM_SWITCH_CPLDS];
     void __iomem * fpga_read_addr;
     uint8_t cpld1_read_addr;
     uint8_t cpld2_read_addr;
@@ -1169,33 +1185,69 @@ static void i2c_core_deinit(unsigned int master_bus,void __iomem *pci_bar){
     iowrite8( ioread8(pci_bar + REG_CTRL) & ~(1 << I2C_CTRL_EN), pci_bar + REG_CTRL);
 }
 
+/*
+ * i2c_xcvr_access() - Optical port xcvr accessor through Switch CPLDs.
+ * @register_address: The xcvr register address.
+ * @portid:           Optical module port index, start from 1.
+ * @data:             Buffer to get or set data.
+ * @rw:               I2C_SMBUS_READ or I2C_SMBUS_WRITE flag.
+ *
+ * Fishbone48 have 2 switch CPLDs. Each CPLD manages 28 ports.
+ *
+ *  +------------------+------------------+
+ *  |1     CPLD1     27|29   CPLD2      55|
+ *  |2               28|30              56|
+ *  +------------------+------------------+
+ *
+ * Return: 0 if success, error code less than zero if fails.
+ */
 static int i2c_xcvr_access(u8 register_address, unsigned int portid, u8 *data, char rw){
     
     u16 dev_addr = 0;
     int err;
+    unsigned int sw_cpld_lock_index = 0;
+
     /* check for portid valid length */
     if(portid < 0 || portid > SFF_PORT_TOTAL){
         return -EINVAL;
     }
     if (portid <= 28 ){
         dev_addr = CPLD1_SLAVE_ADDR;
+        sw_cpld_lock_index = 0;
     }else{
         dev_addr = CPLD2_SLAVE_ADDR;
         portid = portid - 28;
+        sw_cpld_lock_index = 1;
     }
+
+    mutex_lock(&fpga_data->sw_cpld_locks[sw_cpld_lock_index]);
+
     // Select port
-    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], dev_addr, 0x00, I2C_SMBUS_WRITE, 
-        I2C_XCVR_SEL, I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)&portid);
+    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX],
+                          dev_addr,
+                          0x00,
+                          I2C_SMBUS_WRITE,
+                          I2C_XCVR_SEL,
+                          I2C_SMBUS_BYTE_DATA,
+                          (union i2c_smbus_data*)&portid);
     if(err < 0){
-        return err;
+        goto exit_unlock;
     }
     // Read/write port xcvr register
-    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX], dev_addr, 0x00, rw, 
-        register_address , I2C_SMBUS_BYTE_DATA, (union i2c_smbus_data*)data);
+    err = fpga_i2c_access(fpga_data->i2c_adapter[SW_I2C_CPLD_INDEX],
+                          dev_addr,
+                          0x00,
+                          rw,
+                          register_address,
+                          I2C_SMBUS_BYTE_DATA,
+                          (union i2c_smbus_data*)data);
     if(err < 0){
-        return err;
+        goto exit_unlock;
     }
-    return 0;
+
+exit_unlock:
+    mutex_unlock(&fpga_data->sw_cpld_locks[sw_cpld_lock_index]);
+    return err;
 }
 
 static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writing) {
@@ -1946,6 +1998,11 @@ static int fishbone48_drv_probe(struct platform_device *pdev)
     fpga_data->cpld2_read_addr = 0x00;
 
     mutex_init(&fpga_data->fpga_lock);
+
+    for (ret = 0; ret < NUM_SWITCH_CPLDS; ret++) {
+        mutex_init(&fpga_data->sw_cpld_locks[ret]);
+    }
+
     for (ret = I2C_MASTER_CH_1 ; ret <= I2C_MASTER_CH_TOTAL; ret++) {
         mutex_init(&fpga_i2c_master_locks[ret - 1]);
         fpga_i2c_lasted_access_port[ret - 1] = 0;

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -2219,9 +2219,9 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
                 iowrite8( ioread8(fpga_dev.data_base_addr + 0x0108) | 0x0F, fpga_dev.data_base_addr + 0x0108);
             }else if(master_bus == I2C_MASTER_CH_12){
                 // LC1_I2C7_RST_N .. LC1_I2C4_RST_N
-                iowrite8( ioread8(fpga_dev.data_base_addr + 0x0108) & 0x8F, fpga_dev.data_base_addr + 0x0108);
+                iowrite8( ioread8(fpga_dev.data_base_addr + 0x0108) & 0x0F, fpga_dev.data_base_addr + 0x0108);
                 udelay(1);
-                iowrite8( ioread8(fpga_dev.data_base_addr + 0x0108) | 0x70, fpga_dev.data_base_addr + 0x0108);
+                iowrite8( ioread8(fpga_dev.data_base_addr + 0x0108) | 0xF0, fpga_dev.data_base_addr + 0x0108);
             }else if(master_bus == I2C_MASTER_CH_13){
                 // LC2_I2C3_RST_N .. LC2_I2C0_RST_N
                 iowrite8( ioread8(fpga_dev.data_base_addr + 0x010c) & 0xF0, fpga_dev.data_base_addr + 0x010c);
@@ -2229,9 +2229,9 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
                 iowrite8( ioread8(fpga_dev.data_base_addr + 0x010c) | 0x0F, fpga_dev.data_base_addr + 0x010c);
             }else if(master_bus == I2C_MASTER_CH_14){
                 // LC2_I2C7_RST_N .. LC2_I2C4_RST_N
-                iowrite8( ioread8(fpga_dev.data_base_addr + 0x010c) & 0x8F, fpga_dev.data_base_addr + 0x010c);
+                iowrite8( ioread8(fpga_dev.data_base_addr + 0x010c) & 0x0F, fpga_dev.data_base_addr + 0x010c);
                 udelay(1);
-                iowrite8( ioread8(fpga_dev.data_base_addr + 0x010c) | 0x70, fpga_dev.data_base_addr + 0x010c);
+                iowrite8( ioread8(fpga_dev.data_base_addr + 0x010c) | 0xF0, fpga_dev.data_base_addr + 0x010c);
             }
             // clear the last access port 
             fpga_i2c_lasted_access_port[master_bus - 1] = 0;


### PR DESCRIPTION
This change fix incorrect port xcvr statuses return from sysfs. Sometimes the port read as not present while the port is still plugged-in. Checking and found that there is a resource race condition in the sysfs driver. To fix this I add one mutex lock per shared resource to prevent the race condition.

**Platform:** Fishbone32, Fishbone48, Phalanx
**Changes:**
1. Add a resource lock to protect switchboard CPLD from a resource race condition. This will fix the random "EEPROM not detected" issue when the Optical module plugin. 
2. Fix one PCA9548 cannot be reset on each lien card. (Phalanx only)

JIRA: [CAFP-115](http://jira.cn-csh.celestica.com:8080/browse/CAFP-115)