### PR TITLE
[tools/bmc_console_log] Add BMC serial console logging service.

### DIFF
--- a/debian/platform-modules-fishbone32.install
+++ b/debian/platform-modules-fishbone32.install
@@ -13,3 +13,5 @@ tools/bmcutil/bmc-exec /usr/local/bin
 tools/bmc_wdt/bmc_wdt.service etc/systemd/system
 tools/bmc_wdt/bmc_wdt.py /usr/local/etc/
 tools/power_utils/power /usr/local/bin
+tools/bmc_console_log/bmc-console-log /usr/local/bin
+tools/bmc_console_log/bmc-console-log.service etc/systemd/system

--- a/debian/platform-modules-fishbone32.postinst
+++ b/debian/platform-modules-fishbone32.postinst
@@ -13,3 +13,7 @@ systemctl start platform-modules-fishbone32.service
 # Enable heartbeat timer
 systemctl enable bmc_wdt.service
 systemctl start bmc_wdt.service
+
+# Enable bmc console logging service
+systemctl enable bmc-console-log.service
+systemctl start bmc-console-log.service

--- a/debian/platform-modules-fishbone48.install
+++ b/debian/platform-modules-fishbone48.install
@@ -13,3 +13,5 @@ tools/bmcutil/bmc-exec /usr/local/bin
 tools/bmc_wdt/bmc_wdt.service etc/systemd/system
 tools/bmc_wdt/bmc_wdt.py /usr/local/etc/
 tools/power_utils/power /usr/local/bin
+tools/bmc_console_log/bmc-console-log /usr/local/bin
+tools/bmc_console_log/bmc-console-log.service etc/systemd/system

--- a/debian/platform-modules-fishbone48.postinst
+++ b/debian/platform-modules-fishbone48.postinst
@@ -13,3 +13,7 @@ systemctl start platform-modules-fishbone48.service
 # Enable heartbeat timer
 systemctl enable bmc_wdt.service
 systemctl start bmc_wdt.service
+
+# Enable bmc console logging service
+systemctl enable bmc-console-log.service
+systemctl start bmc-console-log.service

--- a/debian/platform-modules-phalanx.install
+++ b/debian/platform-modules-phalanx.install
@@ -13,3 +13,5 @@ tools/bmcutil/bmc-exec /usr/local/bin
 tools/bmc_wdt/bmc_wdt.service etc/systemd/system
 tools/bmc_wdt/bmc_wdt.py /usr/local/etc/
 tools/power_utils/power /usr/local/bin
+tools/bmc_console_log/bmc-console-log /usr/local/bin
+tools/bmc_console_log/bmc-console-log.service etc/systemd/system

--- a/debian/platform-modules-phalanx.postinst
+++ b/debian/platform-modules-phalanx.postinst
@@ -13,3 +13,7 @@ systemctl start platform-modules-phalanx.service
 # Enable heartbeat timer
 systemctl enable bmc_wdt.service
 systemctl start bmc_wdt.service
+
+# Enable bmc console logging service
+systemctl enable bmc-console-log.service
+systemctl start bmc-console-log.service

--- a/tools/bmc_console_log/bmc-console-log
+++ b/tools/bmc_console_log/bmc-console-log
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright 2019-present Celestica. All Rights Reserved.
+#
+# This program file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+#
+# This script control BMC serial console logging service.
+#
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
+PIDFILE=/var/run/bmc-logger.pid
+
+case "$1" in
+start)
+    echo -n "Start BMC serial console logger.."
+    stty -F /dev/ttyS1 9600
+    logger -p user.info -t bmc#console -f /dev/ttyS1 &
+    echo $!> $PIDFILE
+    echo "done."
+    ;;
+stop)
+    echo -n "Stop BMC serial console logger.."
+    if [ -e $PIDFILE ]; then
+      kill `cat $PIDFILE`
+      rm $PIDFILE
+    fi
+    echo "done."
+    ;;
+*)
+    echo "Usage: $0 {start|stop}"
+esac
+
+exit 0

--- a/tools/bmc_console_log/bmc-console-log.service
+++ b/tools/bmc_console_log/bmc-console-log.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=BMC serial console logger
+After=rsyslog.service
+
+[Service]
+Type=forking
+ExecStart=/usr/local/bin/bmc-console-log start
+ExecStop=/usr/local/bin/bmc-console-log stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Log the BMC serial console from _/dev/ttyS1_ and stream them to syslog.
Each log line has a timestamp and tagged with "bmc#console".

**NOTE:** This change **REQUIRED** new Baseboard CPLD with BMC console output mirroring feature. 
JIRA: [CAFP-98](http://jira.cn-csh.celestica.com:8080/browse/CAFP-98)
___
Output on Phalanx:
```
Linux sonic 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    http://azure.github.io/SONiC/

Last login: Sat Dec 17 20:37:26 2016
admin@sonic:~$ sudo -s
root@sonic:/home/admin# systemctl status bmc-console-log.service
● bmc-console-log.service - BMC serial console logger
   Loaded: loaded (/etc/systemd/system/bmc-console-log.service; enabled; vendor preset: enabled)
   Active: active (running) since Sat 2016-12-17 20:24:28 UTC; 16min ago
 Main PID: 7469 (logger)
    Tasks: 1 (limit: 4915)
   Memory: 576.0K
      CPU: 6ms
   CGroup: /system.slice/bmc-console-log.service
           └─7469 logger -p user info -t bmc#console -f /dev/ttyS1

Dec 17 20:24:28 sonic systemd[1]: Starting BMC serial console logger...
Dec 17 20:24:28 sonic bmc-console-log[7467]: Start BMC serial console logger..done.
Dec 17 20:24:28 sonic systemd[1]: Started BMC serial console logger.
Dec 17 20:33:59 sonic bmc#console[7469]: Error: Read failed
Dec 17 20:33:59 sonic bmc#console[7469]: 
Dec 17 20:34:02 sonic bmc#console[7469]: Specified sensor(s) not found!
Dec 17 20:34:02 sonic bmc#console[7469]: 
Dec 17 20:34:02 sonic bmc#console[7469]: PSU dps1100-i2c-24-58 get info Fail!
Dec 17 20:34:02 sonic bmc#console[7469]: 
root@sonic:/home/admin# grep bmc#console /var/log/syslog
Dec 17 20:33:59.482259 sonic INFO bmc#console: Error: Read failed
Dec 17 20:33:59.482874 sonic INFO bmc#console:
Dec 17 20:34:02.035539 sonic INFO bmc#console: Specified sensor(s) not found!
Dec 17 20:34:02.036653 sonic INFO bmc#console:
Dec 17 20:34:02.079082 sonic INFO bmc#console: PSU dps1100-i2c-24-58 get info Fail!
Dec 17 20:34:02.079974 sonic INFO bmc#console:
root@sonic:/home/admin#
```