### PR TITLE
[Fishbones/Phalanx] Fix kernel panic while removing switchboard_fpga 

### DIFF
--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.4-rc2"
+#define MOD_VERSION "0.5.4"
 #else
 #define MOD_VERSION "TEST"
 #endif

--- a/fishbone32/modules/switchboard_fpga.c
+++ b/fishbone32/modules/switchboard_fpga.c
@@ -24,7 +24,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.3"
+#define MOD_VERSION "0.5.4-rc2"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -1238,8 +1238,9 @@ exit_unlock:
 static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writing) {
     int error = 0;
     int Status;
+    unsigned int master_bus;
 
-    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    struct i2c_dev_data *new_data;
     void __iomem *pci_bar = fpga_dev.data_base_addr;
 
     unsigned int REG_FREQ_L;
@@ -1249,7 +1250,16 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     unsigned int REG_STAT;
     unsigned int REG_DATA;
 
-    unsigned int master_bus = new_data->pca9548.master_bus;
+    /* Sanity check for the NULL pointer */
+    if (a == NULL)
+        return -ESHUTDOWN;
+    else
+        new_data = i2c_get_adapdata(a);
+
+    if (new_data == NULL)
+        return -ESHUTDOWN;
+
+    master_bus = new_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
         error = -EINVAL;
@@ -1333,8 +1343,9 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
 static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writing) {
     int error = 0;
     int Status;
+    unsigned int master_bus;
 
-    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    struct i2c_dev_data *new_data;
     void __iomem *pci_bar = fpga_dev.data_base_addr;
 
     unsigned int REG_FREQ_L;
@@ -1344,7 +1355,16 @@ static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writi
     unsigned int REG_STAT;
     unsigned int REG_DATA;
 
-    unsigned int master_bus = new_data->pca9548.master_bus;
+    /* Sanity check for the NULL pointer */
+    if (a == NULL)
+        return -ESHUTDOWN;
+    else
+        new_data = i2c_get_adapdata(a);
+
+    if (new_data == NULL)
+        return -ESHUTDOWN;
+
+    master_bus = new_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
         error = -EINVAL;
@@ -1421,10 +1441,18 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
     REG_STAT   = 0;
     REG_DATA   = 0;
 
-    /* Write the command register */
-    dev_data = i2c_get_adapdata(adapter);
+    /* Sanity check for the NULL pointer */
+    if (adapter == NULL)
+        return -ESHUTDOWN;
+    else
+        dev_data = i2c_get_adapdata(adapter);
+
+    if (dev_data == NULL)
+        return -ESHUTDOWN;
+
     portid = dev_data->portid;
     pci_bar = fpga_dev.data_base_addr;
+    master_bus = dev_data->pca9548.master_bus;
 
 #ifdef DEBUG_KERN
     printk(KERN_INFO "portid %2d|@ 0x%2.2X|f 0x%4.4X|(%d)%-5s| (%d)%-10s|CMD %2.2X "
@@ -1439,9 +1467,6 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
            , cmd);
 #endif
 
-    master_bus = dev_data->pca9548.master_bus;
-    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
-
     /* Map the size to what the chip understands */
     switch (size) {
     case I2C_SMBUS_QUICK:
@@ -1453,16 +1478,14 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         break;
     default:
         printk(KERN_INFO "Unsupported transaction %d\n", size);
-        error = -EOPNOTSUPP;
-        goto Done;
+        return -EOPNOTSUPP;
     }
-
-    master_bus = dev_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
-        error = -EINVAL;
-        goto Done;
+        return -EINVAL;
     }
+
+    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
 
     REG_FREQ_L = I2C_MASTER_FREQ_L  + (master_bus - 1) * 0x20;
     REG_FREQ_H = I2C_MASTER_FREQ_H  + (master_bus - 1) * 0x20;
@@ -1703,7 +1726,15 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
     uint8_t read_channel;
     int retry = 0;
 
-    dev_data = i2c_get_adapdata(adapter);
+    /* Sanity check for the NULL pointer */
+    if (adapter == NULL)
+        return -ESHUTDOWN;
+    else
+        dev_data = i2c_get_adapdata(adapter);
+
+    if (dev_data == NULL)
+        return  -ESHUTDOWN;
+
     master_bus = dev_data->pca9548.master_bus;
     switch_addr = dev_data->pca9548.switch_addr;
     channel = dev_data->pca9548.channel;
@@ -2306,7 +2337,9 @@ static int fpga_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
     printk(KERN_INFO "");
     fpga_version = ioread32(fpga_dev.data_base_addr);
     printk(KERN_INFO "FPGA Version : %8.8x\n", fpga_version);
-    fpgafw_init();
+    if ((err = fpgafw_init()) < 0){
+        goto pci_release;
+    }
     platform_device_register(&fishbone32_dev);
     platform_driver_register(&fishbone32_drv);
     return 0;
@@ -2315,7 +2348,7 @@ pci_release:
     pci_release_regions(pdev);
 pci_disable:
     pci_disable_device(pdev);
-    return -EBUSY;
+    return err;
 }
 
 static void fpga_pci_remove(struct pci_dev *pdev)
@@ -2449,7 +2482,6 @@ static int fpgafw_init(void) {
 
 static void fpgafw_exit(void) {
     device_destroy(fpgafwclass, MKDEV(majorNumber, 0));     // remove the device
-    class_unregister(fpgafwclass);                          // unregister the device class
     class_destroy(fpgafwclass);                             // remove the device class
     unregister_chrdev(majorNumber, DEVICE_NAME);            // unregister the major number
     printk(KERN_INFO "Goodbye!\n");

--- a/fishbone48/modules/switchboard_fpga.c
+++ b/fishbone48/modules/switchboard_fpga.c
@@ -25,7 +25,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.1"
+#define MOD_VERSION "0.5.2-rc2"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -1253,8 +1253,9 @@ exit_unlock:
 static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writing) {
     int error = 0;
     int Status;
+    unsigned int master_bus;
 
-    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    struct i2c_dev_data *new_data;
     void __iomem *pci_bar = fpga_dev.data_base_addr;
 
     unsigned int REG_FREQ_L;
@@ -1264,7 +1265,16 @@ static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writi
     unsigned int REG_STAT;
     unsigned int REG_DATA;
 
-    unsigned int master_bus = new_data->pca9548.master_bus;
+    /* Sanity check for the NULL pointer */
+    if (a == NULL)
+        return -ESHUTDOWN;
+    else
+        new_data = i2c_get_adapdata(a);
+
+    if (new_data == NULL)
+        return -ESHUTDOWN;
+
+    master_bus = new_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
         error = -EINVAL;
@@ -1315,8 +1325,9 @@ static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writi
 static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writing) {
     int error = 0;
     int Status;
+    unsigned int master_bus;
 
-    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    struct i2c_dev_data *new_data;
     void __iomem *pci_bar = fpga_dev.data_base_addr;
 
     unsigned int REG_FREQ_L;
@@ -1326,7 +1337,16 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     unsigned int REG_STAT;
     unsigned int REG_DATA;
 
-    unsigned int master_bus = new_data->pca9548.master_bus;
+    /* Sanity check for the NULL pointer */
+    if (a == NULL)
+        return -ESHUTDOWN;
+    else
+        new_data = i2c_get_adapdata(a);
+
+    if (new_data == NULL)
+        return -ESHUTDOWN;
+
+    master_bus = new_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
         error = -EINVAL;
@@ -1427,10 +1447,18 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
     REG_STAT   = 0;
     REG_DATA   = 0;
 
-    /* Write the command register */
-    dev_data = i2c_get_adapdata(adapter);
+    /* Sanity check for the NULL pointer */
+    if (adapter == NULL)
+        return -ESHUTDOWN;
+    else
+        dev_data = i2c_get_adapdata(adapter);
+
+    if (dev_data == NULL)
+        return -ESHUTDOWN;
+
     portid = dev_data->portid;
     pci_bar = fpga_dev.data_base_addr;
+    master_bus = dev_data->pca9548.master_bus;
 
 #ifdef DEBUG_KERN
     printk(KERN_INFO "portid %2d|@ 0x%2.2X|f 0x%4.4X|(%d)%-5s| (%d)%-10s|CMD %2.2X "
@@ -1445,9 +1473,6 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
            , cmd);
 #endif
 
-    master_bus = dev_data->pca9548.master_bus;
-    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
-
     /* Map the size to what the chip understands */
     switch (size) {
     case I2C_SMBUS_QUICK:
@@ -1459,14 +1484,14 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         break;
     default:
         printk(KERN_INFO "Unsupported transaction %d\n", size);
-        error = -EOPNOTSUPP;
-        goto Done;
+        return -EOPNOTSUPP;
     }
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
-        error = -EINVAL;
-        goto Done;
+        return -EINVAL;
     }
+
+    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
 
     REG_FREQ_L = I2C_MASTER_FREQ_L  + (master_bus - 1) * 0x20;
     REG_FREQ_H = I2C_MASTER_FREQ_H  + (master_bus - 1) * 0x20;
@@ -1704,7 +1729,15 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
     uint8_t read_channel;
     int retry = 0;
 
-    dev_data = i2c_get_adapdata(adapter);
+    /* Sanity check for the NULL pointer */
+    if (adapter == NULL)
+        return -ESHUTDOWN;
+    else
+        dev_data = i2c_get_adapdata(adapter);
+
+    if (dev_data == NULL)
+        return -ESHUTDOWN;
+    
     master_bus = dev_data->pca9548.master_bus;
     switch_addr = dev_data->pca9548.switch_addr;
     channel = dev_data->pca9548.channel;
@@ -2313,7 +2346,9 @@ static int fpga_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
     printk(KERN_INFO "");
     fpga_version = ioread32(fpga_dev.data_base_addr);
     printk(KERN_INFO "FPGA Version : %8.8x\n", fpga_version);
-    fpgafw_init();
+    if ((err = fpgafw_init()) < 0){
+        goto pci_release;
+    }
     platform_device_register(&fishbone48_dev);
     platform_driver_register(&fishbone48_drv);
     return 0;
@@ -2322,7 +2357,7 @@ pci_release:
     pci_release_regions(pdev);
 pci_disable:
     pci_disable_device(pdev);
-    return -EBUSY;
+    return err;
 }
 
 static void fpga_pci_remove(struct pci_dev *pdev)
@@ -2456,7 +2491,6 @@ static int fpgafw_init(void) {
 
 static void fpgafw_exit(void) {
     device_destroy(fpgafwclass, MKDEV(majorNumber, 0));     // remove the device
-    class_unregister(fpgafwclass);                          // unregister the device class
     class_destroy(fpgafwclass);                             // remove the device class
     unregister_chrdev(majorNumber, DEVICE_NAME);            // unregister the major number
     printk(KERN_INFO "Goodbye!\n");

--- a/fishbone48/modules/switchboard_fpga.c
+++ b/fishbone48/modules/switchboard_fpga.c
@@ -25,7 +25,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.2-rc2"
+#define MOD_VERSION "0.5.2"
 #else
 #define MOD_VERSION "TEST"
 #endif

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -23,7 +23,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.3-rc2"
+#define MOD_VERSION "0.5.3"
 #else
 #define MOD_VERSION "TEST"
 #endif

--- a/phalanx/modules/switchboard_fpga.c
+++ b/phalanx/modules/switchboard_fpga.c
@@ -23,7 +23,7 @@
  */
 
 #ifndef TEST_MODE
-#define MOD_VERSION "0.5.2"
+#define MOD_VERSION "0.5.3-rc2"
 #else
 #define MOD_VERSION "TEST"
 #endif
@@ -1659,8 +1659,9 @@ exit_unlock:
 static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writing) {
     int error = 0;
     int Status;
+    unsigned int master_bus;
 
-    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    struct i2c_dev_data *new_data;
     void __iomem *pci_bar = fpga_dev.data_base_addr;
 
     unsigned int REG_FREQ_L;
@@ -1670,7 +1671,16 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
     unsigned int REG_STAT;
     unsigned int REG_DATA;
 
-    unsigned int master_bus = new_data->pca9548.master_bus;
+    /* Sanity check for the NULL pointer */
+    if (a == NULL)
+        return -ESHUTDOWN;
+    else
+        new_data = i2c_get_adapdata(a);
+
+    if (new_data == NULL)
+        return -ESHUTDOWN;
+
+    master_bus = new_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
         error = -EINVAL;
@@ -1754,8 +1764,9 @@ static int i2c_wait_ack(struct i2c_adapter *a, unsigned long timeout, int writin
 static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writing) {
     int error = 0;
     int Status;
+    unsigned int master_bus;
 
-    struct i2c_dev_data *new_data = i2c_get_adapdata(a);
+    struct i2c_dev_data *new_data;
     void __iomem *pci_bar = fpga_dev.data_base_addr;
 
     unsigned int REG_FREQ_L;
@@ -1765,7 +1776,16 @@ static int i2c_wait_stop(struct i2c_adapter *a, unsigned long timeout, int writi
     unsigned int REG_STAT;
     unsigned int REG_DATA;
 
-    unsigned int master_bus = new_data->pca9548.master_bus;
+    /* Sanity check for the NULL pointer */
+    if (a == NULL)
+        return -ESHUTDOWN;
+    else
+        new_data = i2c_get_adapdata(a);
+
+    if (new_data == NULL)
+        return -ESHUTDOWN;
+
+    master_bus = new_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
         error = -EINVAL;
@@ -1842,10 +1862,18 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
     REG_STAT   = 0;
     REG_DATA   = 0;
 
-    /* Write the command register */
-    dev_data = i2c_get_adapdata(adapter);
+    /* Sanity check for the NULL pointer */
+    if (adapter == NULL)
+        return -ESHUTDOWN;
+    else
+        dev_data = i2c_get_adapdata(adapter);
+
+    if (dev_data == NULL)
+        return -ESHUTDOWN;
+
     portid = dev_data->portid;
     pci_bar = fpga_dev.data_base_addr;
+    master_bus = dev_data->pca9548.master_bus;
 
 #ifdef DEBUG_KERN
     printk(KERN_INFO "portid %2d|@ 0x%2.2X|f 0x%4.4X|(%d)%-5s| (%d)%-10s|CMD %2.2X "
@@ -1860,9 +1888,6 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
            , cmd);
 #endif
 
-    master_bus = dev_data->pca9548.master_bus;
-    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
-
     /* Map the size to what the chip understands */
     switch (size) {
     case I2C_SMBUS_QUICK:
@@ -1874,16 +1899,14 @@ static int smbus_access(struct i2c_adapter *adapter, u16 addr,
         break;
     default:
         printk(KERN_INFO "Unsupported transaction %d\n", size);
-        error = -EOPNOTSUPP;
-        goto Done;
+        return -EOPNOTSUPP;
     }
-
-    master_bus = dev_data->pca9548.master_bus;
 
     if (master_bus < I2C_MASTER_CH_1 || master_bus > I2C_MASTER_CH_TOTAL) {
-        error = -EINVAL;
-        goto Done;
+        return -EINVAL;
     }
+
+    error = i2c_core_init(master_bus, I2C_DIV_100K, fpga_dev.data_base_addr);
 
     REG_FREQ_L = I2C_MASTER_FREQ_L  + (master_bus - 1) * 0x20;
     REG_FREQ_H = I2C_MASTER_FREQ_H  + (master_bus - 1) * 0x20;
@@ -2124,7 +2147,15 @@ static int fpga_i2c_access(struct i2c_adapter *adapter, u16 addr,
     uint8_t read_channel;
     int retry = 0;
 
-    dev_data = i2c_get_adapdata(adapter);
+    /* Sanity check for the NULL pointer */
+    if (adapter == NULL)
+        return -ESHUTDOWN;
+    else
+        dev_data = i2c_get_adapdata(adapter);
+
+    if (dev_data == NULL)
+        return -ESHUTDOWN;
+
     master_bus = dev_data->pca9548.master_bus;
     switch_addr = dev_data->pca9548.switch_addr;
     channel = dev_data->pca9548.channel;
@@ -2876,7 +2907,9 @@ static int fpga_pci_probe(struct pci_dev *pdev, const struct pci_device_id *id)
     printk(KERN_INFO "");
     fpga_version = ioread32(fpga_dev.data_base_addr);
     printk(KERN_INFO "FPGA Version : %8.8x\n", fpga_version);
-    fpgafw_init();
+    if ((err = fpgafw_init()) < 0){
+        goto pci_release;
+    }
     platform_device_register(&phalanx_dev);
     platform_driver_register(&phalanx_drv);
     return 0;
@@ -2885,7 +2918,7 @@ pci_release:
     pci_release_regions(pdev);
 pci_disable:
     pci_disable_device(pdev);
-    return -EBUSY;
+    return err;
 }
 
 static void fpga_pci_remove(struct pci_dev *pdev)
@@ -3019,7 +3052,6 @@ static int fpgafw_init(void) {
 
 static void fpgafw_exit(void) {
     device_destroy(fpgafwclass, MKDEV(majorNumber, 0));     // remove the device
-    class_unregister(fpgafwclass);                          // unregister the device class
     class_destroy(fpgafwclass);                             // remove the device class
     unregister_chrdev(majorNumber, DEVICE_NAME);            // unregister the major number
     printk(KERN_INFO "Goodbye!\n");


### PR DESCRIPTION
1. The candidate of #47 with minimal changes.
The _NULL_ pointer condition check is added to i2c-access functions.  If _NULL_ is found, a function will not perform I2c operation and exit with **[ESHUTDOWN](https://www.kernel.org/doc/Documentation/i2c/fault-codes)** status indicates that the adapter is not ready to use (suspended).

Changes applied to followings:
 * i2c_wait_stop()
 * i2c_wait_ack()
 * smbus_access()
 * fpga_i2c_access()

2. Add the fix for 100 cycle module load/unload cause kernel panic.
 The fix removes duplicate class unregister statement in `fpgafw_exit()` function.

JIARA: [CAFP-139](http://jira.cn-csh.celestica.com:8080/browse/CAFP-139)

**NOTE:** The module versions have -rc2 suffix, it will be removed if this candidate is selected. 
